### PR TITLE
Allow exec from /usr/libexec & co. with AppArmor

### DIFF
--- a/etc/firejail-default
+++ b/etc/firejail-default
@@ -77,7 +77,7 @@ owner /proc/@{PID}/clear_refs w,
 /{,run/firejail/mnt/oroot/}{,usr/,usr/local/}bin/** ix,
 /{,run/firejail/mnt/oroot/}{,usr/,usr/local/}sbin/** ix,
 /{,run/firejail/mnt/oroot/}{,usr/,usr/local/}games/** ix,
-/{,run/firejail/mnt/oroot/}{,usr/,usr/local/}lib{,32,64}/** ix,
+/{,run/firejail/mnt/oroot/}{,usr/,usr/local/}lib{,32,64,exec}/** ix,
 /{,run/firejail/mnt/oroot/}{,usr/,usr/local/}opt/** ix,
 #/{,run/firejail/mnt/oroot/}home/** ix,
 


### PR DESCRIPTION
With AppArmor enabled and the `firejail-default` profile, execution is not allowed from _/usr/libexec_. On my machine (Gentoo), Git stores its helpers in _/usr/libexec/git-core/_, so Firejail's `git.profile` (which has AppArmor enabled) prevents it from executing these helpers (which are needed for e.g. cloning a repo over HTTPS).

This PR adds _/usr/libexec_ and friends to the paths where execution is allowed in Firejail's AppArmor profile.